### PR TITLE
Support 8-bit word-ending characters in WordStar files

### DIFF
--- a/wsconvert.py
+++ b/wsconvert.py
@@ -71,6 +71,8 @@ def converttext(data):
                 #    outdata.pop()
             if linetype != 1: # we are in a dotline => ignore it
                 outdata.append(data[counter])
+        elif data[counter]<0xFF:
+            outdata.append(data[counter] - 0x80)
     return outdata
 
 print("Basic WordStar to Markdown converter")


### PR DESCRIPTION
I found that the existing version would often ignore the last letter/character or words in docs I created with WordStar 3.x (CP/M).  The final character of a word is often an 8-bit character, so I added support to properly convert those.

Tested with WordStar 3.3 (CP/M) and Wordstar 4 (MS-DOS)