### PR TITLE
Extended character may also be 0x1B+0x80

### DIFF
--- a/wsconvert.py
+++ b/wsconvert.py
@@ -42,7 +42,7 @@ def converttext(data):
         if data[counter] == 0x1A:
             break
         # Extended character
-        elif data[counter]==0x1B:
+        elif data[counter]==0x1B or data[counter]==0x1B+0x80:
             outdata.append(data[counter+1])
             counter += 2
         # Symmetrical sequence: 1Dh special character


### PR DESCRIPTION
If the extended character (0x1B) is at the end of a word, it seems to be changed to 0x1B. In those cases, the extended character was not considered as such.

Changed the elif condition so that this case is taken into account as well.