### PR TITLE
Start with newline=True so dotlines at the top are detected

### DIFF
--- a/wsconvert.py
+++ b/wsconvert.py
@@ -33,7 +33,7 @@ def handleblock(block):
 
 def converttext(data):
     counter=-1
-    newline = False
+    newline = True
     linetype = 0
     outdata=bytearray()
     while counter<len(data)-1:


### PR DESCRIPTION
Dotlines at the very top of a file are not detected and the corresponding dot command is printed to the output file.

Starting with newline=True seems to fix the issue.