### PR TITLE
Correctly manage input files without extension

### DIFF
--- a/wsconvert.py
+++ b/wsconvert.py
@@ -91,6 +91,8 @@ if args.output:
 else:
     extension = ".txt" if args.textmode else ".md"
     pp=args.ws_file.find('.')
+    if pp == -1:  # ws_file has no extension
+        pp = len(args.ws_file)
     outfilename=args.ws_file[0:pp]+extension
 
 #Read file


### PR DESCRIPTION
The script was incorrectly dropping the last character, of an input file's name without extension, when automatically naming the output file.